### PR TITLE
Fix workspace build failure caused by ext-php-rs version mismatch in example

### DIFF
--- a/examples/reqwest/Cargo.toml
+++ b/examples/reqwest/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 crate-type = ["cdylib"]
 
 [dependencies]
-php-tokio = "^0.1.4"
-ext-php-rs = { version = "^0.10.2", features = ["anyhow"] }
+php-tokio = { path = "../.." }
+ext-php-rs = { version = "^0.15.6", features = ["anyhow"] }
 reqwest = "^0.11"
 anyhow = "^1.0"


### PR DESCRIPTION
## Summary

Building the workspace currently fails due to an ext-php-rs version mismatch
between the root crate and the `examples/reqwest` crate.

The example depends on:
 * php-tokio = "^0.1.4"
 * ext-php-rs = "^0.10.2"

However, the workspace root depends on:
 * ext-php-rs = "^0.15.6"


This results in two different generations of `ext-php-rs` being pulled into
the same dependency graph. Since both versions link against `clang`
(using `links = "clang"`), Cargo aborts with a native linking conflict.

## Fix

- Switch the example to use a path dependency to the local workspace version of `php-tokio`
- Align `ext-php-rs` to `^0.15.6` to match the workspace root

This ensures consistent dependency resolution and restores successful
workspace builds.

## Result

`cargo build` now succeeds when building the full workspace.